### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     magrittr,
     stringr,
     devtools,
-    styler,
+    styler (>= 1.0.2),
     purrr,
     roxygen2,
     checkmate,


### PR DESCRIPTION
styler `v1.0.2` is now available on CRAN and I suggest to add a minimal version dependency to exampletestr to import this version. Most notable fixes (including critical fixes like implicit dependency removal) were already present in a prior release `v1.0.1`, but currently, exampletestr does not specify a minimal version for styler. You can find the changelog [here](http://styler.r-lib.org/news/index.html).