### PR TITLE
require styler 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Imports:
     rlang (>= 0.3.3),
     roxygen2,
     stringr (>= 1.2.0),
-    styler (>= 1.1.1),
+    styler (>= 1.2.0),
     usethis (>= 1.5.1),
     withr (>= 2.1.0)
 Suggests: 


### PR DESCRIPTION
In particular because {{ is now recognized as rlang *curly curly*. Before, the line was broken between the two curly braces. Also, there were many other improvements over the last two years. For details see https://github.com/r-lib/styler/releases/tag/v1.2.0.