### PR TITLE
Use `usethis::proj_path()` only with relative paths

### DIFF
--- a/R/exemplar.R
+++ b/R/exemplar.R
@@ -177,15 +177,15 @@ make_test_shell_fun <- function(fun, pkg_dir = ".",
   readr::write_lines(test_shell, test_file_name)
   withr::with_options(list(usethis.quiet = usethis_quiet_init), {
     usethis::ui_info(
-      "Wrote {usethis::ui_path(usethis::proj_path(test_file_name),
+      "Wrote {usethis::ui_path(test_file_name,
                                usethis::proj_path())}."
     )
     if (open) file.edit(test_file_name)
     usethis::ui_todo(
       stringr::str_glue(
         "Complete the unit tests in ",
-        "{usethis::ui_path(usethis::proj_path(test_file_name),
-                                    usethis::proj_path())}."
+        "{usethis::ui_path(test_file_name,
+                           usethis::proj_path())}."
       )
     )
   })
@@ -241,15 +241,15 @@ make_tests_shells_file <- function(r_file_name, pkg_dir = ".",
   readr::write_lines(combined, test_file_name)
   withr::with_options(list(usethis.quiet = usethis_quiet_init), {
     usethis::ui_info(
-      "Wrote {usethis::ui_path(usethis::proj_path(test_file_name),
+      "Wrote {usethis::ui_path(test_file_name,
                                usethis::proj_path())}."
     )
     if (open) file.edit(test_file_name)
     usethis::ui_todo(
       stringr::str_glue(
         "Complete the unit tests in ",
-        "{usethis::ui_path(usethis::proj_path(test_file_name),
-                                    usethis::proj_path())}."
+        "{usethis::ui_path(test_file_name,
+                           usethis::proj_path())}."
       )
     )
   })

--- a/tests/testthat/test-functions.R
+++ b/tests/testthat/test-functions.R
@@ -43,7 +43,7 @@ test_that("`make_tests_shell_fun()` works", {
   make_test_shell_fun("str_detect()", open = FALSE, pkg_dir = pkg_dir)
   expect_equal(
     readr::read_lines(
-      usethis::proj_path("/tests/testthat/test-str_detect-examples.R"),
+      usethis::proj_path("tests/testthat/test-str_detect-examples.R"),
       lazy = FALSE
     ),
     c(


### PR DESCRIPTION
This changes the use of `usethis::proj_path()` in a few places to align with the recent change that only allows its use with paths relative to the project root - really only in messages and one test.

Fixes #11.